### PR TITLE
Fix memory leak

### DIFF
--- a/src/main/java/org/aksw/sparqlmap/core/db/DBAccess.java
+++ b/src/main/java/org/aksw/sparqlmap/core/db/DBAccess.java
@@ -46,31 +46,27 @@ public class DBAccess {
 	private Connector dbConnector;
 
 
-	public com.hp.hpl.jena.query.ResultSet executeSQL(TranslationContext context, String baseUri) throws SQLException{
+	public DeUnionResultWrapper executeSQL(TranslationContext context, String baseUri) throws SQLException {
 		context.profileStartPhase("Connection Acquisition");
-		Connection connect  = dbConnector.getConnection();
+		Connection connect = dbConnector.getConnection();
 		java.sql.Statement stmt = connect.createStatement();
-		
-		
-		
-		if(log.isDebugEnabled()){
-			log.debug("Executing translated Query: " +  context.getSqlQuery());
+		connect.setAutoCommit(false);
+		stmt.setFetchSize(500);
+
+		if (log.isDebugEnabled()) {
+			log.debug("Executing translated Query: " + context.getSqlQuery());
 		}
-		context.profileStartPhase("Query Execution");
-		com.hp.hpl.jena.query.ResultSet wrap;
+		DeUnionResultWrapper wrap;
 		try {
 			ResultSet rs = stmt.executeQuery(context.getSqlQuery());
-			
-			wrap = new DeUnionResultWrapper(new  SQLResultSetWrapper(rs, connect,
-					dataTypeHelper, baseUri, context));
+			wrap = new DeUnionResultWrapper(new SQLResultSetWrapper(rs, connect, dataTypeHelper, baseUri, context));
 		} catch (SQLException e) {
 			log.error("Error executing Query: " + context.getSqlQuery());
 			throw new SQLException(e);
 		}
-		
-		return  wrap;
-	}
 
+		return wrap;
+	}
 
 
 

--- a/src/main/java/org/aksw/sparqlmap/core/db/DeUnionResultWrapper.java
+++ b/src/main/java/org/aksw/sparqlmap/core/db/DeUnionResultWrapper.java
@@ -165,6 +165,13 @@ public class DeUnionResultWrapper implements ResultSet{
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+	public void close() {
+		srs.close();
+		suffix2duvar.clear();
+		non_du_var.clear();
+		vars.clear();
+	}
 	
 
 	

--- a/src/main/java/org/aksw/sparqlmap/core/db/SQLResultSetWrapper.java
+++ b/src/main/java/org/aksw/sparqlmap/core/db/SQLResultSetWrapper.java
@@ -368,12 +368,11 @@ public class SQLResultSetWrapper implements com.hp.hpl.jena.query.ResultSet {
     tcontext.profileStop();
 
     try {
-      if (rs.isClosed() == false) {
+      if (!rs.isClosed()) {
         rs.close();
         conn.close();
       }
     } catch (Throwable e) {
-      // TODO Auto-generated catch block
       log.error("Error:", e);
     }
   }


### PR DESCRIPTION
Fetch size was implicitly 0 meaning it will cache the entire SQL query.
This leads to out of memory errors on large datasets.

There's some other changes as well that were made trying to figure out the memory problems but the only relevant thing is the cache size in DBAccess.
